### PR TITLE
integration between api and dist - add source msg passing

### DIFF
--- a/dist/dist.go
+++ b/dist/dist.go
@@ -213,8 +213,27 @@ func (de *DistEngine) handleAddSource(message []byte) error {
 	} else {
 		level.Info(de.logger).Log("msg", fmt.Sprintf("Received add source event %+v", addSourceMsg))
 		//TODO : add logic to update local prometheus config with new source info
+
 	}
 	return nil
+}
+
+func (de * DistEngine) SendSourceAddToPeer(sourceGuid, sourceUrl, peerAddress string){
+	addSourceMsg := AddSourceMsg{
+		SourceScrapeTargetURL: sourceUrl,
+		SourceGuuid:           sourceGuid,
+	}
+	if msgBytes, marshal_err := json.Marshal(addSourceMsg); marshal_err != nil {
+		level.Error(de.logger).Log("msg", "Error marshalling add source message to peer", "error", marshal_err)
+	} else {
+		distMessage := DistMessage{
+			Mtype: MsgType_AddSource,
+			Data:  msgBytes,
+		}
+		if send_err := de.sendMessage(peerAddress, distMessage); send_err != nil {
+			level.Error(de.logger).Log("msg", "Error sending add source message to peer", "error", send_err)
+		}
+	}
 }
 
 func (de *DistEngine) LookupGuid(inGuid string) Node {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1239,6 +1239,15 @@ func (api *API) addTarget(r *http.Request) apiFuncResult {
 	target_url := r.FormValue("url")
 
 	// lookup goes here
+	lookedup_node := api.de.LookupGuid(target_id)
+	local_id := api.de.GetLocalId()
+
+	if local_id == lookedup_node.Guuid {
+		// add config here
+	}else {
+		// add config on the remote peer lookedup_node
+		api.de.SendSourceAddToPeer(target_id, target_url, lookedup_node.Address)
+	}
 
 	// addTarget function: curl -X POST -g 'http://localhost:9090/api/v1/admin/targets/add_target?id=ABCDEF1&url=localhost:8082'
 	if !targets.AddTargetToConfig(target_id, target_url) {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->